### PR TITLE
Add Jest and Supertest for API testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ This application visualizes the flow of loan applications through different 'buc
     - Then, it starts the Node.js server (on port 3001), which now also serves the static files from `dist/`.
     - Open `http://localhost:3001` in your browser.
 
+## Testing
+
+Run the Jest test suite:
+
+```bash
+npm test
+```
+
 ## Changelog
 
 - **2024-07-26:** Refactored frontend to use Vite build tool. Implemented `itemTemplate` for custom cluster content.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
       "devDependencies": {
         "nodemon": "^3.1.4",
         "npm-run-all": "^4.1.5",
-        "vite": "^5.3.5"
+        "vite": "^5.3.5",
+        "jest": "^29.7.0",
+        "supertest": "^6.3.4"
       }
     },
     "node_modules/@egjs/hammerjs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev:backend": "nodemon server.js",
     "dev": "npm-run-all --parallel dev:frontend dev:backend",
     "build": "vite build",
-    "start": "npm run build && node server.js"
+    "start": "npm run build && node server.js",
+    "test": "jest"
   },
   "keywords": [
     "visualization",
@@ -27,6 +28,8 @@
   "devDependencies": {
     "nodemon": "^3.1.4",
     "npm-run-all": "^4.1.5",
-    "vite": "^5.3.5"
+    "vite": "^5.3.5",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -51,9 +51,13 @@ if (process.env.NODE_ENV === 'production') {
     });
 }
 
-app.listen(port, () => {
-    console.log(`Backend server listening at http://localhost:${port}`);
-    if (process.env.NODE_ENV !== 'production') {
-        console.log('Run `npm run dev` to start frontend dev server.');
-    }
-}); 
+if (require.main === module) {
+    app.listen(port, () => {
+        console.log(`Backend server listening at http://localhost:${port}`);
+        if (process.env.NODE_ENV !== 'production') {
+            console.log('Run `npm run dev` to start frontend dev server.');
+        }
+    });
+}
+
+module.exports = app;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,20 @@
+const request = require('supertest');
+const axios = require('axios');
+
+// set fake API token so server does not exit
+process.env.API_TOKEN = 'test-token';
+
+jest.mock('axios');
+
+const app = require('../server');
+
+describe('GET /api/buckets', () => {
+  it('returns mocked bucket data', async () => {
+    const mockData = [{ id: 1, name: 'Bucket A' }];
+    axios.get.mockResolvedValue({ data: mockData });
+
+    const res = await request(app).get('/api/buckets');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(mockData);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest dev dependencies
- expose Express app for testing
- create simple Jest test for `/api/buckets`
- document running tests in README

## Testing
- `npm test` *(fails: jest not found)*
