### PR TITLE
Fix newline in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 .Spotlight-V100
 .Trashes
 ehthumbs.db
-Thumbs.db 
+Thumbs.db


### PR DESCRIPTION
## Summary
- trim space after `Thumbs.db` and ensure newline at end of `.gitignore`

## Testing
- `grep -n "[ ]$" -n .gitignore`
