### PR TITLE
Fix gitignore newline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ yarn-error.log*
 .Spotlight-V100
 .Trashes
 ehthumbs.db
-Thumbs.db 
+Thumbs.db


### PR DESCRIPTION
## Summary
- remove trailing space after `Thumbs.db`
- ensure `.gitignore` ends with a newline

## Testing
- `npm test` *(fails: Missing script `test`)*