### PR TITLE
Add jest + server test

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ This application visualizes the flow of loan applications through different 'buc
     - Then, it starts the Node.js server (on port 3001), which now also serves the static files from `dist/`.
     - Open `http://localhost:3001` in your browser.
 
+## Running Tests
+
+Unit tests use **Jest** and **Supertest**. Execute all tests with:
+
+```bash
+npm test
+```
+
 ## Changelog
 
 - **2024-07-26:** Refactored frontend to use Vite build tool. Implemented `itemTemplate` for custom cluster content.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
       "devDependencies": {
         "nodemon": "^3.1.4",
         "npm-run-all": "^4.1.5",
-        "vite": "^5.3.5"
+        "vite": "^5.3.5",
+        "jest": "^29.7.0",
+        "supertest": "^6.3.3"
       }
     },
     "node_modules/@egjs/hammerjs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev:backend": "nodemon server.js",
     "dev": "npm-run-all --parallel dev:frontend dev:backend",
     "build": "vite build",
-    "start": "npm run build && node server.js"
+    "start": "npm run build && node server.js",
+    "test": "jest"
   },
   "keywords": [
     "visualization",
@@ -27,6 +28,8 @@
   "devDependencies": {
     "nodemon": "^3.1.4",
     "npm-run-all": "^4.1.5",
-    "vite": "^5.3.5"
+    "vite": "^5.3.5",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -51,9 +51,13 @@ if (process.env.NODE_ENV === 'production') {
     });
 }
 
-app.listen(port, () => {
-    console.log(`Backend server listening at http://localhost:${port}`);
-    if (process.env.NODE_ENV !== 'production') {
-        console.log('Run `npm run dev` to start frontend dev server.');
-    }
-}); 
+if (require.main === module) {
+    app.listen(port, () => {
+        console.log(`Backend server listening at http://localhost:${port}`);
+        if (process.env.NODE_ENV !== 'production') {
+            console.log('Run `npm run dev` to start frontend dev server.');
+        }
+    });
+}
+
+module.exports = app;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,20 @@
+const request = require('supertest');
+const axios = require('axios');
+
+jest.mock('axios');
+
+let app;
+
+beforeAll(() => {
+  process.env.API_TOKEN = 'test-token';
+  app = require('../server');
+});
+
+test('GET /api/buckets returns mocked bucket data', async () => {
+  const sample = [{ id: 1, name: 'Sample Bucket' }];
+  axios.get.mockResolvedValue({ data: sample });
+
+  const res = await request(app).get('/api/buckets');
+  expect(res.statusCode).toBe(200);
+  expect(res.body).toEqual(sample);
+});


### PR DESCRIPTION
## Summary
- install jest and supertest in devDependencies
- export the Express app and only start server when executed directly
- add a sample Jest/Supertest test for the API
- document running tests in README

## Testing
- `npm test` *(fails: jest not found)*